### PR TITLE
Fix config flow docstring

### DIFF
--- a/custom_components/xiaomi_tv/config_flow.py
+++ b/custom_components/xiaomi_tv/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for the smart curtain integration."""
+"""Config flow for the Xiaomi TV integration."""
 from __future__ import annotations
 
 from typing import Any


### PR DESCRIPTION
## Summary
- update Config Flow module docstring

## Testing
- `flake8 custom_components` *(fails: continuation line under-indented, SyntaxError in unrelated files)*
- `isort --diff --check-only custom_components`


------
https://chatgpt.com/codex/tasks/task_e_6840c786af548320914c39b43323b67e

## Summary by Sourcery

Correct and enhance the Xiaomi TV integration’s config_flow module docstring to improve clarity and satisfy linting requirements

Enhancements:
- Adjust docstring formatting to resolve flake8 indentation errors

Documentation:
- Update the module-level docstring in custom_components/xiaomi_tv/config_flow with refined description and proper indentation