### PR TITLE
Fix async_select_source with executor job

### DIFF
--- a/custom_components/xiaomi_tv/media_player.py
+++ b/custom_components/xiaomi_tv/media_player.py
@@ -140,9 +140,8 @@ class XiaomiTV(MediaPlayerEntity):
                 )
             )
         else:
-            self._tv.change_source(source)
-            await self._hass.async_create_task(
-                self._tv.change_source(source)
+            await self._hass.async_add_executor_job(
+                self._tv.change_source, source
             )
         self._hass.data[DOMAIN][self._config_id].update({'source': source})
 


### PR DESCRIPTION
## Summary
- fix TV source selection

## Testing
- `flake8 custom_components`
- `isort --diff --check-only custom_components`


------
https://chatgpt.com/codex/tasks/task_e_6840c782b9488320bbd05d6612de4fcf

## Summary by Sourcery

Bug Fixes:
- Replace direct change_source calls with hass.async_add_executor_job in async_select_source