### PR TITLE
Fix thumbnail URL string

### DIFF
--- a/custom_components/xiaomi_tv/__init__.py
+++ b/custom_components/xiaomi_tv/__init__.py
@@ -64,9 +64,10 @@ async def hack_pymitv(hass: HomeAssistant):
                 ) as f:
                     line_number = 1
                     for ip_line in f:
-                        if hack.get('from') in ip_line and \
-                                ((hack.get('line') is None) or
-                                (hack.get('line') == line_number)):
+                        if hack.get('from') in ip_line and (
+                            (hack.get('line') is None)
+                            or (hack.get('line') == line_number)
+                        ):
                             hacked = True
                             ip_line = ip_line.replace(
                                 hack.get('from'),

--- a/custom_components/xiaomi_tv/media_player.py
+++ b/custom_components/xiaomi_tv/media_player.py
@@ -162,13 +162,18 @@ class XiaomiTV(MediaPlayerEntity):
 
         children = []
         for item in media_list:
+            sanitized_icon_url = item['IconURL'].replace('\\', '')
+            thumbnail_url = (
+                f"{get_url(self._hass)}/api/xiaomi_tv/proxy/?url="
+                f"{quote(sanitized_icon_url)}"
+            )
             children.append(
                 BrowseMedia(
                     title=item['AppName'],
                     media_class=MediaClass.APP,
                     media_content_id=item['PackageName'],
                     media_content_type=MediaType.APP,
-                    thumbnail=f"{get_url(self._hass)}/api/xiaomi_tv/proxy/?url={quote(item['IconURL'].replace('\\', ''))}",
+                    thumbnail=thumbnail_url,
                     can_play=True,
                     can_expand=False,
                     children=[]

--- a/custom_components/xiaomi_tv/media_player.py
+++ b/custom_components/xiaomi_tv/media_player.py
@@ -165,7 +165,7 @@ class XiaomiTV(MediaPlayerEntity):
             sanitized_icon_url = item['IconURL'].replace('\\', '')
             thumbnail_url = (
                 f"{get_url(self._hass)}/api/xiaomi_tv/proxy/?url="
-                f"{quote(sanitized_icon_url)}"
+                f"{quote(sanitized_icon_url, safe=':/')}"
             )
             children.append(
                 BrowseMedia(


### PR DESCRIPTION
## Summary
- ensure sanitized icon URL becomes a single string for BrowseMedia

## Testing
- `flake8 .`
- `pylint custom_components/xiaomi_tv | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6840c56c68e48320baac129180dc8dd4

## Summary by Sourcery

Sanitize icon URLs by removing backslashes before constructing BrowseMedia thumbnail proxies and reformat conditional logic in _hack_pymitv_sync for readability

Bug Fixes:
- Remove backslashes from item IconURL before quoting to ensure thumbnail URL is a valid single string

Enhancements:
- Reformat the multiline conditional in _hack_pymitv_sync for improved readability