### PR TITLE
Fix flake8 errors

### DIFF
--- a/custom_components/xiaomi_tv/__init__.py
+++ b/custom_components/xiaomi_tv/__init__.py
@@ -64,9 +64,13 @@ async def hack_pymitv(hass: HomeAssistant):
                 ) as f:
                     line_number = 1
                     for ip_line in f:
-                        if hack.get('from') in ip_line and \
-                                ((hack.get('line') is None) or
-                                (hack.get('line') == line_number)):
+                        if (
+                            hack.get('from') in ip_line
+                            and (
+                                hack.get('line') is None
+                                or hack.get('line') == line_number
+                            )
+                        ):
                             hacked = True
                             ip_line = ip_line.replace(
                                 hack.get('from'),

--- a/custom_components/xiaomi_tv/media_player.py
+++ b/custom_components/xiaomi_tv/media_player.py
@@ -161,13 +161,17 @@ class XiaomiTV(MediaPlayerEntity):
 
         children = []
         for item in media_list:
+            icon_url = item['IconURL'].replace('\\', '')
             children.append(
                 BrowseMedia(
                     title=item['AppName'],
                     media_class=MediaClass.APP,
                     media_content_id=item['PackageName'],
                     media_content_type=MediaType.APP,
-                    thumbnail=f"{get_url(self._hass)}/api/xiaomi_tv/proxy/?url={quote(item['IconURL'].replace('\\', ''))}",
+                    thumbnail=(
+                        f"{get_url(self._hass)}/api/xiaomi_tv/proxy/?url="
+                        f"{quote(icon_url)}"
+                    ),
                     can_play=True,
                     can_expand=False,
                     children=[]

--- a/custom_components/xiaomi_tv/media_player.py
+++ b/custom_components/xiaomi_tv/media_player.py
@@ -161,17 +161,18 @@ class XiaomiTV(MediaPlayerEntity):
 
         children = []
         for item in media_list:
-            icon_url = item['IconURL'].replace('\\', '')
+            sanitized_icon_url = item['IconURL'].replace('\\', '')
+            thumbnail_url = (
+                f"{get_url(self._hass)}/api/xiaomi_tv/proxy/?url="
+                f"{quote(sanitized_icon_url, safe=':/')}"
+            )
             children.append(
                 BrowseMedia(
                     title=item['AppName'],
                     media_class=MediaClass.APP,
                     media_content_id=item['PackageName'],
                     media_content_type=MediaType.APP,
-                    thumbnail=(
-                        f"{get_url(self._hass)}/api/xiaomi_tv/proxy/?url="
-                        f"{quote(icon_url)}"
-                    ),
+                    thumbnail=thumbnail_url,
                     can_play=True,
                     can_expand=False,
                     children=[]


### PR DESCRIPTION
## Summary
- fix indent in `hack_pymitv`
- sanitize icon URLs before putting them in f-strings

## Testing
- `flake8 custom_components`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415d366bb08320aaa9d927f16106ee

## Summary by Sourcery

Fix flake8 linting errors and ensure icon URLs are sanitized before building proxy thumbnail URLs

Bug Fixes:
- Correct multiline conditional indentation to satisfy flake8 rules
- Strip backslashes from icon URLs before URL-encoding to prevent invalid proxy thumbnail URLs