### PR TITLE
Add Russian, French, German, Japanese and Chinese translations

### DIFF
--- a/custom_components/xiaomi_tv/translations/de.json
+++ b/custom_components/xiaomi_tv/translations/de.json
@@ -1,0 +1,31 @@
+{
+  "issues": {
+    "restart_required": {
+      "title": "Neustart erforderlich",
+      "fix_flow": {
+        "step": {
+          "confirm_restart": {
+            "title": "Neustart erforderlich",
+            "description": "Zum Abschluss des Herunterladens/Aktualisierens von {name} ist ein Neustart von Home Assistant erforderlich. Klicken Sie auf \"Senden\", um jetzt neu zu starten."
+          }
+        }
+      }
+    }
+  },
+  "config": {
+    "title": "Xiaomi TV",
+    "step": {
+      "user": {
+        "title": "Mit Xiaomi TV verbinden",
+        "description": "Bitte geben Sie die IP-Adresse und den Port Ihres Xiaomi TV ein.",
+        "data": {
+          "host": "IP-Adresse",
+          "port": "Port"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Bitte prüfen Sie die IP-Adresse und den Port Ihres Xiaomi TV."
+    }
+  }
+}

--- a/custom_components/xiaomi_tv/translations/fr.json
+++ b/custom_components/xiaomi_tv/translations/fr.json
@@ -1,0 +1,31 @@
+{
+  "issues": {
+    "restart_required": {
+      "title": "Redémarrage requis",
+      "fix_flow": {
+        "step": {
+          "confirm_restart": {
+            "title": "Redémarrage requis",
+            "description": "Le redémarrage de Home Assistant est nécessaire pour terminer le téléchargement/la mise à jour de {name}. Cliquez sur \"Soumettre\" pour redémarrer maintenant."
+          }
+        }
+      }
+    }
+  },
+  "config": {
+    "title": "Xiaomi TV",
+    "step": {
+      "user": {
+        "title": "Connecter la Xiaomi TV",
+        "description": "Veuillez saisir l'adresse IP et le port de votre Xiaomi TV.",
+        "data": {
+          "host": "Adresse IP",
+          "port": "Port"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Veuillez vérifier l'adresse IP et le port de votre Xiaomi TV."
+    }
+  }
+}

--- a/custom_components/xiaomi_tv/translations/ja.json
+++ b/custom_components/xiaomi_tv/translations/ja.json
@@ -1,0 +1,31 @@
+{
+  "issues": {
+    "restart_required": {
+      "title": "再起動が必要です",
+      "fix_flow": {
+        "step": {
+          "confirm_restart": {
+            "title": "再起動が必要です",
+            "description": "Home Assistant のダウンロードまたは更新を完了するには {name} を再起動する必要があります。\u3000\u3000送信をクリックすると今すぐ再起動します。"
+          }
+        }
+      }
+    }
+  },
+  "config": {
+    "title": "Xiaomi TV",
+    "step": {
+      "user": {
+        "title": "Xiaomi TV に接続",
+        "description": "Xiaomi TV の IP アドレスとポートを入力してください。",
+        "data": {
+          "host": "IP アドレス",
+          "port": "ポート"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Xiaomi TV の IP アドレスとポートを確認してください。"
+    }
+  }
+}

--- a/custom_components/xiaomi_tv/translations/ru.json
+++ b/custom_components/xiaomi_tv/translations/ru.json
@@ -1,0 +1,31 @@
+{
+  "issues": {
+    "restart_required": {
+      "title": "Требуется перезагрузка",
+      "fix_flow": {
+        "step": {
+          "confirm_restart": {
+            "title": "Требуется перезагрузка",
+            "description": "Чтобы завершить загрузку/обновление {name}, требуется перезапуск Home Assistant. Нажмите \"Отправить\", чтобы перезапустить сейчас."
+          }
+        }
+      }
+    }
+  },
+  "config": {
+    "title": "Xiaomi TV",
+    "step": {
+      "user": {
+        "title": "Подключение к Xiaomi TV",
+        "description": "Пожалуйста, укажите IP-адрес и порт вашего телевизора Xiaomi.",
+        "data": {
+          "host": "IP-адрес",
+          "port": "Порт"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Проверьте IP-адрес и порт вашего Xiaomi TV."
+    }
+  }
+}

--- a/custom_components/xiaomi_tv/translations/zh-Hans.json
+++ b/custom_components/xiaomi_tv/translations/zh-Hans.json
@@ -1,0 +1,31 @@
+{
+  "issues": {
+    "restart_required": {
+      "title": "需要重启",
+      "fix_flow": {
+        "step": {
+          "confirm_restart": {
+            "title": "需要重启",
+            "description": "需要重启 Home Assistant 以完成 {name} 的下载/更新，点击提交立即重启。"
+          }
+        }
+      }
+    }
+  },
+  "config": {
+    "title": "Xiaomi TV",
+    "step": {
+      "user": {
+        "title": "连接到小米电视",
+        "description": "请输入您小米电视的 IP 地址和端口。",
+        "data": {
+          "host": "IP 地址",
+          "port": "端口"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "请检查您小米电视的 IP 地址和端口。"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- translate strings for more languages

## Testing
- `flake8 custom_components`
- `isort --diff --check-only custom_components`

------
https://chatgpt.com/codex/tasks/task_e_684545ac214c8320960374f728387ba3