### PR TITLE
Add state restoration

### DIFF
--- a/custom_components/xiaomi_tv/manifest.json
+++ b/custom_components/xiaomi_tv/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/Arbuzov/home_assistant_xiaomi_tv/issues",
   "loggers": ["pymitv"],
   "requirements": ["pymitv==1.5.0"],
-  "version": "2025.06.08"
+  "version": "2025.06.09"
 }


### PR DESCRIPTION
## Summary
- support restoring entity state by using `RestoreEntity`
- update version to 2025.06.09

## Testing
- `flake8 custom_components`
- `isort --diff --check-only custom_components`

------
https://chatgpt.com/codex/tasks/task_e_684b4a6c03cc83209ab684efe62a277e

## Summary by Sourcery

Add state restoration to Xiaomi TV integration by leveraging RestoreEntity and update version

Enhancements:
- Implement RestoreEntity in media_player and switch components to restore last power state and input source on startup
- Persist state and source in hass.data and initialize defaults when no prior state exists
- Expose current input source via extra_state_attributes on the media player

Build:
- Bump manifest version to 2025.06.09