### PR TITLE
Fix restart issue placeholder

### DIFF
--- a/custom_components/xiaomi_tv/__init__.py
+++ b/custom_components/xiaomi_tv/__init__.py
@@ -108,5 +108,6 @@ async def hack_pymitv(hass: HomeAssistant):
             is_fixable=True,
             issue_domain=DOMAIN,
             severity=IssueSeverity.WARNING,
-            translation_key="restart_required"
+            translation_key="restart_required",
+            translation_placeholders={"name": "pymitv"},
         )


### PR DESCRIPTION
## Summary
- fix missing `name` placeholder when creating restart-required issue

## Testing
- `flake8 custom_components`
- `isort --diff --check-only custom_components`


------
https://chatgpt.com/codex/tasks/task_e_684d8333824c8320ab7af557cc5d8b9b

## Summary by Sourcery

Bug Fixes:
- Add the `name` placeholder to the translation placeholders for restart-required issues.