### PR TITLE
Remove outdated pymitv hack notification

### DIFF
--- a/custom_components/xiaomi_tv/__init__.py
+++ b/custom_components/xiaomi_tv/__init__.py
@@ -92,15 +92,6 @@ async def hack_pymitv(hass: HomeAssistant):
     hacked = await hass.async_add_executor_job(_hack_pymitv_sync)
 
     if hacked:
-        await hass.services.async_call(
-            'persistent_notification',
-            'create',
-            {
-                'message': 'Please reboot HA to apply the changes',
-                'title': 'Pymitv was hacked',
-                'notification_id': f'{DOMAIN}_event'
-            }
-        )
         async_create_issue(
             hass=hass,
             domain=DOMAIN,


### PR DESCRIPTION
## Summary
- drop old persistent notification for the pymitv hack

## Testing
- `flake8 custom_components`
- `isort --diff --check-only custom_components`


------
https://chatgpt.com/codex/tasks/task_e_687e1c79bba483208a0db969169a4429

## Summary by Sourcery

Chores:
- Remove the old persistent notification creation when pymitv sync hack succeeds