### PR TITLE
Improve HTTP session reuse

### DIFF
--- a/custom_components/xiaomi_tv/media_player.py
+++ b/custom_components/xiaomi_tv/media_player.py
@@ -18,6 +18,7 @@ from homeassistant.components.media_player import (PLATFORM_SCHEMA,
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.network import get_url
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -114,6 +115,7 @@ class XiaomiTV(MediaPlayerEntity, RestoreEntity):
         self._config_id = f'{DOMAIN}_{self._ip}'
         self._attr_unique_id = f'{self._config_id}_{self.__class__.__name__}'
         self._hass = hass
+        self._session = async_get_clientsession(hass)
         self._volume = 1
         self._max_volume = 1
 
@@ -250,11 +252,10 @@ class XiaomiTV(MediaPlayerEntity, RestoreEntity):
         tv_url = 'http://{}:6095/controller?action=getVolume'.format(
             self._tv.ip_address)
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(tv_url) as resp:
-                    response = await resp.json(content_type='text/json')
-                    self._volume = response['data']['volume']
-                    self._max_volume = response['data']['maxVolume']
+            async with self._session.get(tv_url) as resp:
+                response = await resp.json(content_type='text/json')
+                self._volume = response['data']['volume']
+                self._max_volume = response['data']['maxVolume']
         except aiohttp.ClientError as error:
             LOGGER.warning(error)
 
@@ -265,8 +266,7 @@ class XiaomiTV(MediaPlayerEntity, RestoreEntity):
             f'?action=startapp&type=packagename&packagename={package}'
         )
         try:
-            async with aiohttp.ClientSession() as session:
-                await session.get(tv_url)
+            await self._session.get(tv_url)
         except aiohttp.ClientError as error:
             LOGGER.warning(error)
 
@@ -277,11 +277,10 @@ class XiaomiTV(MediaPlayerEntity, RestoreEntity):
             '?action=getinstalledapp&count=999&changeIcon=1'
         )
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(tv_url) as resp:
-                    response = await resp.json(content_type='text/json')
-                    LOGGER.debug(response['data'])
-                    return response['data']['AppInfo']
+            async with self._session.get(tv_url) as resp:
+                response = await resp.json(content_type='text/json')
+                LOGGER.debug(response['data'])
+                return response['data']['AppInfo']
         except aiohttp.ClientError as error:
             LOGGER.warning(error)
             return []


### PR DESCRIPTION
## Summary
- reuse the shared aiohttp client session in `XiaomiTV` entity

## Testing
- `flake8 custom_components`
- `isort --diff --check-only custom_components`

------
https://chatgpt.com/codex/tasks/task_e_688d0bf646248320a39e8b7c2eb9db82